### PR TITLE
Feat: Only display a notification once #24

### DIFF
--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -29,6 +29,11 @@ local function get_return_key(key)
 end
 
 local function handler(key)
+   -- plugin disabled
+   if is_disabled() then
+      return get_return_key(key)
+   end
+
    local curr_time = util.get_time()
    if curr_time - last_notification > config.max_time then
       util.reset_notification()
@@ -46,11 +51,6 @@ local function handler(key)
          last_notification = util.get_time()
       end
       return ""
-   end
-
-   -- plugin disabled
-   if is_disabled() then
-      return get_return_key(key)
    end
 
    -- reset

--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -1,6 +1,7 @@
 local util = require("hardtime.util")
 
 local last_time = util.get_time()
+local last_notification = util.get_time()
 local last_count = 0
 local last_key
 local last_keys = ""
@@ -28,19 +29,28 @@ local function get_return_key(key)
 end
 
 local function handler(key)
-   -- plugin disabled
-   if is_disabled() then
-      return get_return_key(key)
+   local curr_time = util.get_time()
+   if curr_time - last_notification > config.max_time then
+      util.reset_notification()
    end
 
    -- key disabled
    if config.disabled_keys[key] then
-      if config.notification then
+      if
+         config.notification
+         and curr_time - last_notification > config.max_time
+      then
          vim.schedule(function()
             util.notify("The " .. key .. " key is disabled!")
          end)
+         last_notification = util.get_time()
       end
       return ""
+   end
+
+   -- plugin disabled
+   if is_disabled() then
+      return get_return_key(key)
    end
 
    -- reset
@@ -54,8 +64,6 @@ local function handler(key)
    end
 
    -- restrict
-   local curr_time = util.get_time()
-
    if
       last_count < config.max_count
       or curr_time - last_time > config.max_time
@@ -66,6 +74,7 @@ local function handler(key)
          or (config.allow_different_key and key ~= last_key)
       then
          last_count = 1
+         util.reset_notification()
       else
          last_count = last_count + 1
       end
@@ -79,6 +88,7 @@ local function handler(key)
       vim.schedule(function()
          util.notify("You pressed the " .. key .. " key too soon!")
       end)
+      last_notification = util.get_time()
    end
    last_key = key
    return ""

--- a/lua/hardtime/util.lua
+++ b/lua/hardtime/util.lua
@@ -1,4 +1,5 @@
 local M = {}
+local previous_text
 
 function M.get_time()
    return vim.fn.reltimefloat(vim.fn.reltime()) * 1000
@@ -13,7 +14,14 @@ function M.try_eval(expression)
 end
 
 function M.notify(text)
-   vim.notify(text, vim.log.levels.WARN, { title = "hardtime" })
+   if text ~= previous_text then
+      vim.notify(text, vim.log.levels.WARN, { title = "hardtime" })
+   end
+   previous_text = text
+end
+
+function M.reset_notification()
+   previous_text = nil
 end
 
 return M


### PR DESCRIPTION
This PR implements logic to avoid displaying multiple times the same notification message (mostly affecting nvim-notify users).

Behaviour:
A notification message is repeated only if `max_time` is reached

Fixes #24 