### PR TITLE
Feature: Expose state of 'enabled'

### DIFF
--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -88,7 +88,7 @@ local function handler(key)
 end
 
 local M = {}
-local enabled = false
+M.enabled = false
 
 local keys_groups = {
    config.resetting_keys,
@@ -97,11 +97,11 @@ local keys_groups = {
 }
 
 function M.enable()
-   if enabled then
+   if M.enabled then
       return
    end
 
-   enabled = true
+   M.enabled = true
    mappings = vim.api.nvim_get_keymap("n")
 
    if config.disable_mouse then
@@ -118,11 +118,11 @@ function M.enable()
 end
 
 function M.disable()
-   if not enabled then
+   if not M.enabled then
       return
    end
 
-   enabled = false
+   M.enabled = false
    vim.opt.mouse = "nvi"
 
    for _, keys in ipairs(keys_groups) do
@@ -133,7 +133,7 @@ function M.disable()
 end
 
 function M.toggle()
-   (enabled and M.disable or M.enable)()
+   (M.enabled and M.disable or M.enable)()
 end
 
 function M.setup(user_config)
@@ -162,7 +162,7 @@ function M.setup(user_config)
       last_keys = last_keys .. key
       last_key = key
 
-      if not config.hint or not enabled or vim.fn.reg_executing() ~= "" then
+      if not config.hint or not M.enabled or vim.fn.reg_executing() ~= "" then
          return
       end
 

--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -88,7 +88,7 @@ local function handler(key)
 end
 
 local M = {}
-M.enabled = false
+M.is_enabled = false
 
 local keys_groups = {
    config.resetting_keys,
@@ -97,11 +97,11 @@ local keys_groups = {
 }
 
 function M.enable()
-   if M.enabled then
+   if M.is_enabled then
       return
    end
 
-   M.enabled = true
+   M.is_enabled = true
    mappings = vim.api.nvim_get_keymap("n")
 
    if config.disable_mouse then
@@ -118,11 +118,11 @@ function M.enable()
 end
 
 function M.disable()
-   if not M.enabled then
+   if not M.is_enabled then
       return
    end
 
-   M.enabled = false
+   M.is_enabled = false
    vim.opt.mouse = "nvi"
 
    for _, keys in ipairs(keys_groups) do
@@ -133,7 +133,7 @@ function M.disable()
 end
 
 function M.toggle()
-   (M.enabled and M.disable or M.enable)()
+   (M.is_enabled and M.disable or M.enable)()
 end
 
 function M.setup(user_config)
@@ -162,7 +162,7 @@ function M.setup(user_config)
       last_keys = last_keys .. key
       last_key = key
 
-      if not config.hint or not M.enabled or vim.fn.reg_executing() ~= "" then
+      if not config.hint or not M.is_enabled or vim.fn.reg_executing() ~= "" then
          return
       end
 


### PR DESCRIPTION
Hi!

Adds a `M.is_enabled()` function to expose the current state of hardtime.  Useful for statuslines and many different things :)

Apologies if this is already possible - I had a very quick look and did not see it.

Thanks!