### PR TITLE
docs: add workflow to convert README to vimdoc readme to vimdoc

### DIFF
--- a/.github/workflows/panvimdoc.yml
+++ b/.github/workflows/panvimdoc.yml
@@ -1,0 +1,38 @@
+name: panvimdoc
+on:
+  push:
+    branches:
+      - '**'
+    paths: 
+      - README.md
+      - .github/workflows/panvimdoc.yml
+  workflow_dispatch:
+
+jobs:
+  vimdoc:
+    runs-on: ubuntu-latest
+    name: generate vimdoc
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: panvimdoc
+        uses: kdheepak/panvimdoc@main
+        with:
+          vimdoc: hardtime.nvim
+          pandoc: "README.md"
+          version: "NVIM v0.7+"
+          toc: true
+          demojify: true
+          dedupsubheadings: false
+          treesitter: true
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: ${{ github.head_ref }}
+          commit_message: "chore(build): auto-generate vimdoc"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "github-actions[bot]@users.noreply.github.com"
+          commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          file_pattern: doc/*.txt
+
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- panvimdoc-ignore-start -->
+
 <h1 align="center">
 hardtime.nvim
 </h1>
@@ -27,6 +29,8 @@ hardtime.nvim
   <img src="https://github.com/m4xshen/hardtime.nvim/assets/74842863/117a8d30-64ba-4ca9-8414-5c493cbe8a70" width="700" />
 </p>
 
+<!-- panvimdoc-ignore-end -->
+
 ## 📃 Introduction
 
 A Neovim plugin helping you establish good command workflow and habit
@@ -39,6 +43,7 @@ A Neovim plugin helping you establish good command workflow and habit
 - Get report for your most common bad habits for improvement
 
 Recommended workflow:
+
 1. Avoid using the mouse and arrow keys if they are not at the home row of your keyboard.
 2. Use relative jump (eg: `5j` `12-`) for vertical movement within the screen.
 3. Use `CTRL-U` `CTRL-D` `CTRL-B` `CTRL-F` `gg` `G` for vertical movement outside the screen.
@@ -74,13 +79,14 @@ require("hardtime").setup()
 If you want to see the hint messages in insert and visual mode, set the `'showmode'` to false.
 
 But if you want to see both the hint message and current mode you can setup with one of the following methods:
+
 - Display the mode on status line and set `'showmode'` to false. You can do this with some statusline plugin such as lualine.nvim.
 - Set the `'cmdheight'` to 2 so that the hint message won't be replaced by mode message.
 - Use nvim-notify to display hint messages on the right top corner instead of commandline.
    
 ## 🚀 Usage
 
-hardtime.nvim is enable by default. You can change its state through commands:
+hardtime.nvim is enabled by default. You can change it's state with the following commands:
 
 - `:Hardtime enable` enable hardtime.nvim
 - `:Hardtime disable` disable hardtime.nvim
@@ -115,23 +121,25 @@ disabled_keys = {
 
 ### Options
 
-| Option Name         | Type                    | Default Valuae |  Meaning                                             |
-|---------------------|-------------------------|----------------|-----------------------------------------------------|
-| `max_time`          | number                  | `1000` | Maximum time (in milliseconds) to consider key presses as repeated. |
-| `max_count`         | number                  | `2` | Maximum count of repeated key presses allowed within the `max_time` period. |
-| `disable_mouse`     | boolean                 | `true` | Disable mouse support. |
-| `hint`              | boolean                 | `true` | Enable hint messages for better commands. |
-| `notification`      | boolean                 | `true` | Enable notification messages for restricted and disabled keys. |
-| `allow_different_key` | boolean                | `false` | Allow different keys to reset the count. |
-| `enabled`           | boolean                 | `true` | Whether the plugin is enabled by default or not. |
-| `resetting_keys`    | table of strings/table pair | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | Keys in what modes that reset the count. |
-| `restricted_keys`   | table of strings/table pair | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | Keys in what modes triggering the count mechanism. |
-| `restriction_mode`  | string (`"block" or "hint"`) | `"block"` | The behavior when `restricted_keys` trigger count mechanism.
-| `disabled_keys`     | table of strings/table pair | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | Keys in what modes are disabled. |
-| `disabled_filetypes` | table of strings        | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | `hardtime.nvim` is disabled under these filetypes. |
-| `hints`             | table                   | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) |`key` is a string pattern you want to match, `value` is a table of hint message and pattern length. Learn more about [Lua string pattern](https://www.lua.org/pil/20.2.html). |
+| Option Name           | Type                         | Default Valuae                                                                           | Meaning                                                                                                                                                                       |
+| --------------------- | ---------------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `max_time`            | number                       | `1000`                                                                                   | Maximum time (in milliseconds) to consider key presses as repeated.                                                                                                           |
+| `max_count`           | number                       | `2`                                                                                      | Maximum count of repeated key presses allowed within the `max_time` period.                                                                                                   |
+| `disable_mouse`       | boolean                      | `true`                                                                                   | Disable mouse support.                                                                                                                                                        |
+| `hint`                | boolean                      | `true`                                                                                   | Enable hint messages for better commands.                                                                                                                                     |
+| `notification`        | boolean                      | `true`                                                                                   | Enable notification messages for restricted and disabled keys.                                                                                                                |
+| `allow_different_key` | boolean                      | `false`                                                                                  | Allow different keys to reset the count.                                                                                                                                      |
+| `enabled`             | boolean                      | `true`                                                                                   | Whether the plugin is enabled by default or not.                                                                                                                              |
+| `resetting_keys`      | table of strings/table pair  | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | Keys in what modes that reset the count.                                                                                                                                      |
+| `restricted_keys`     | table of strings/table pair  | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | Keys in what modes triggering the count mechanism.                                                                                                                            |
+| `restriction_mode`    | string (`"block" or "hint"`) | `"block"`                                                                                | The behavior when `restricted_keys` trigger count mechanism.                                                                                                                  |
+| `disabled_keys`       | table of strings/table pair  | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | Keys in what modes are disabled.                                                                                                                                              |
+| `disabled_filetypes`  | table of strings             | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | `hardtime.nvim` is disabled under these filetypes.                                                                                                                            |
+| `hints`               | table                        | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | `key` is a string pattern you want to match, `value` is a table of hint message and pattern length. Learn more about [Lua string pattern](https://www.lua.org/pil/20.2.html). |
 
-`hints` example (these two are default hints):
+### `hints` example 
+
+These are two default hints:
 
 ```lua
 hints = {
@@ -160,3 +168,4 @@ Check out some examples of custom hint in [discussion](https://github.com/m4xshe
 hardtime.nvim is participating in Hacktoberfest 2023! 🎉
 
 Please read [CONTRIBUTING.md](https://github.com/m4xshen/hardtime.nvim/blob/main/CONTRIBUTING.md).
+

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Learn more in this [blog post](https://m4xshen.dev/posts/vim-command-workflow/)
 
 1. Install via your favorite package manager.
 
-```Lua
+```lua
 -- lazy.nvim
 {
    "m4xshen/hardtime.nvim",
@@ -72,7 +72,7 @@ Learn more in this [blog post](https://m4xshen.dev/posts/vim-command-workflow/)
 ```
 
 2. Setup the plugin in your `init.lua`. This step is not needed with lazy.nvim if `opts` is set as above.
-```Lua
+```lua
 require("hardtime").setup()
 ```
 
@@ -86,7 +86,7 @@ But if you want to see both the hint message and current mode you can setup with
    
 ## 🚀 Usage
 
-hardtime.nvim is enabled by default. You can change it's state with the following commands:
+hardtime.nvim is enabled by default. You can change its state with the following commands:
 
 - `:Hardtime enable` enable hardtime.nvim
 - `:Hardtime disable` disable hardtime.nvim

--- a/doc/hardtime.nvim.txt
+++ b/doc/hardtime.nvim.txt
@@ -73,7 +73,7 @@ with one of the following methods:
 
 USAGE                                                    *hardtime.nvim-usage*
 
-hardtime.nvim is enabled by default. You can change it’s state with the
+hardtime.nvim is enabled by default. You can change its state with the
 following commands:
 
 - `:Hardtime enable` enable hardtime.nvim

--- a/doc/hardtime.nvim.txt
+++ b/doc/hardtime.nvim.txt
@@ -1,0 +1,203 @@
+*hardtime.nvim.txt*         For NVIM v0.7+        Last change: 2023 October 04
+
+==============================================================================
+Table of Contents                            *hardtime.nvim-table-of-contents*
+
+  - Introduction                                  |hardtime.nvim-introduction|
+  - Features                                          |hardtime.nvim-features|
+  - Requirements                                  |hardtime.nvim-requirements|
+  - Installation                                  |hardtime.nvim-installation|
+  - Usage                                                |hardtime.nvim-usage|
+  - Configuration                                |hardtime.nvim-configuration|
+  - Contributing                                  |hardtime.nvim-contributing|
+
+INTRODUCTION                                      *hardtime.nvim-introduction*
+
+A Neovim plugin helping you establish good command workflow and habit
+
+
+FEATURES                                              *hardtime.nvim-features*
+
+- Block repeated keys within a period of time
+- Print hints about better commands eg: Use `ci"` instead of `di"i`
+- Customizable options for restricted keys, disabled keys, etc.
+- Get report for your most common bad habits for improvement
+
+Recommended workflow:
+
+1. Avoid using the mouse and arrow keys if they are not at the home row of your keyboard.
+2. Use relative jump (eg: `5j` `12-`) for vertical movement within the screen.
+3. Use `CTRL-U` `CTRL-D` `CTRL-B` `CTRL-F` `gg` `G` for vertical movement outside the screen.
+4. Use word-motion (`w` `W` `b` `B` `e` `E` `ge` `gE`) for short-distance horizontal movement.
+5. Use `f` `F` `t` `T` `,` `;` `0` `^` `$` for medium to long-distance horizontal movement.
+6. Use operator + motion/text-object (eg: `ci{` `y5j` `dap`) whenever possible.
+7. Use `%` and square bracket commands (see |[|) to jump between brackets.
+
+Learn more in this blog post <https://m4xshen.dev/posts/vim-command-workflow/>
+
+
+REQUIREMENTS                                      *hardtime.nvim-requirements*
+
+- Neovim >= v0.7.0 <https://github.com/neovim/neovim/releases/tag/v0.7.0>
+
+
+INSTALLATION                                      *hardtime.nvim-installation*
+
+1. Install via your favorite package manager.
+
+>lua
+    -- lazy.nvim
+    {
+       "m4xshen/hardtime.nvim",
+       dependencies = { "MunifTanjim/nui.nvim", "nvim-lua/plenary.nvim" },
+       opts = {}
+    },
+<
+
+1. Setup the plugin in your `init.lua`. This step is not needed with lazy.nvim if `opts` is set as above.
+
+>lua
+    require("hardtime").setup()
+<
+
+If you want to see the hint messages in insert and visual mode, set the
+`'showmode'` to false.
+
+But if you want to see both the hint message and current mode you can setup
+with one of the following methods:
+
+- Display the mode on status line and set `'showmode'` to false. You can do this with some statusline plugin such as lualine.nvim.
+- Set the `'cmdheight'` to 2 so that the hint message won’t be replaced by mode message.
+- Use nvim-notify to display hint messages on the right top corner instead of commandline.
+
+
+USAGE                                                    *hardtime.nvim-usage*
+
+hardtime.nvim is enabled by default. You can change it’s state with the
+following commands:
+
+- `:Hardtime enable` enable hardtime.nvim
+- `:Hardtime disable` disable hardtime.nvim
+- `:Hardtime toggle` toggle hardtime.nvim
+
+You can view the most frequently seen hints with `:Hardtime report`.
+
+Your log file is at `~/.cache/nvim/hardtime.nvim.log`.
+
+
+CONFIGURATION                                    *hardtime.nvim-configuration*
+
+You can pass your config table into the `setup()` function or `opts` if you use
+lazy.nvim.
+
+If the option is a boolean, number, or array, your value will overwrite the
+default configuration.
+
+Example:
+
+>lua
+    -- Add "oil" to the disabled_filetypes
+    disabled_filetypes = { "qf", "netrw", "NvimTree", "lazy", "mason", "oil" },
+<
+
+If the option is a table with a `key = value` pair, your value will overwrite
+the default if the key exists, and the pair will be appended to the default
+configuration if the key doesn’t exist. You can set `key = {}` to remove the
+default key-value pair.
+
+Example:
+
+>lua
+    -- Remove <Up> keys and append <Space> to the disabled_keys
+    disabled_keys = {
+       ["<Up>"] = {},
+       ["<Space>"] = { "n", "x" },
+    },
+<
+
+
+OPTIONS ~
+
+  --------------------------------------------------------------------------------------------------------
+  Option Name           Type                  Default Valuae       Meaning
+  --------------------- --------------------- -------------------- ---------------------------------------
+  max_time              number                1000                 Maximum time (in milliseconds) to
+                                                                   consider key presses as repeated.
+
+  max_count             number                2                    Maximum count of repeated key presses
+                                                                   allowed within the max_time period.
+
+  disable_mouse         boolean               true                 Disable mouse support.
+
+  hint                  boolean               true                 Enable hint messages for better
+                                                                   commands.
+
+  notification          boolean               true                 Enable notification messages for
+                                                                   restricted and disabled keys.
+
+  allow_different_key   boolean               false                Allow different keys to reset the
+                                                                   count.
+
+  enabled               boolean               true                 Whether the plugin is enabled by
+                                                                   default or not.
+
+  resetting_keys        table of              See Config           Keys in what modes that reset the
+                        strings/table pair                         count.
+
+  restricted_keys       table of              See Config           Keys in what modes triggering the count
+                        strings/table pair                         mechanism.
+
+  restriction_mode      string                "block"              The behavior when restricted_keys
+                        ("block" or "hint")                        trigger count mechanism.
+
+  disabled_keys         table of              See Config           Keys in what modes are disabled.
+                        strings/table pair                         
+
+  disabled_filetypes    table of strings      See Config           hardtime.nvim is disabled under these
+                                                                   filetypes.
+
+  hints                 table                 See Config           key is a string pattern you want to
+                                                                   match, value is a table of hint message
+                                                                   and pattern length. Learn more about
+                                                                   Lua string pattern.
+  --------------------------------------------------------------------------------------------------------
+
+HINTS EXAMPLE ~
+
+These are two default hints:
+
+>lua
+    hints = {
+       ["k%^"] = {
+          message = function()
+             return "Use - instead of k^" -- return the hint message you want to display
+          end,
+          length = 2, -- the length of actual key strokes that matches this pattern
+       },
+       ["d[tTfF].i"] = { -- this matches d + {t/T/f/F} + {any character} + i
+          message = function(keys) -- keys is a string of key strokes that matches the pattern
+             return "Use " .. "c" .. keys:sub(2, 3) .. " instead of " .. keys
+             -- example: Use ct( instead of dt(i
+          end,
+          length = 4,
+       },
+    }
+<
+
+Check out some examples of custom hint in discussion
+<https://github.com/m4xshen/hardtime.nvim/discussions/categories/custom-hints>!
+
+
+DEFAULT CONFIG ~
+
+
+CONTRIBUTING                                      *hardtime.nvim-contributing*
+
+hardtime.nvim is participating in Hacktoberfest 2023!
+
+Pleaseread CONTRIBUTING.md
+<https://github.com/m4xshen/hardtime.nvim/blob/main/CONTRIBUTING.md>.
+
+Generated by panvimdoc <https://github.com/kdheepak/panvimdoc>
+
+vim:tw=78:ts=8:noet:ft=help:norl:


### PR DESCRIPTION
👋 I created a Github workflow to run [panvimdoc](https://github.com/kdheepak/panvimdoc) on every push that modifies `README.md`. I tweaked some formatting in the README to allow it to generate correctly.

You may have to enable *read and write access* to your github actions to allow the bot to commit changes. See [setting-the-permissions-of-the-github_token-for-your-repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository) 

Let me know what you think! #hacktoberfest :tada:

It can also be ran locally via:
```
./panvimdoc.sh --project-name hardtime.nvim  --input-file "../hardtime.nvim/README.md" --vim-version "NVIM v0.7+" --toc true --demojify true --dedup-subheadings false
```