### PR TITLE
feat: add neotest-summary to disabled filetypes

### DIFF
--- a/lua/hardtime/config.lua
+++ b/lua/hardtime/config.lua
@@ -81,6 +81,7 @@ M.config = {
       "help",
       "lazy",
       "mason",
+      "neotest-summary",
       "neo-tree",
       "neo-tree-popup",
       "netrw",


### PR DESCRIPTION
Summary Panel window filetype used in https://github.com/nvim-neotest/neotest