### PR TITLE
feat(config): disable on "Trouble" filetype

### DIFF
--- a/doc/hardtime.nvim.txt
+++ b/doc/hardtime.nvim.txt
@@ -1,4 +1,4 @@
-*hardtime.nvim.txt*      For Neovim >= 0.7.0     Last change: 2024 February 03
+*hardtime.nvim.txt*       For Neovim >= 0.7.0       Last change: 2024 March 04
 
 ==============================================================================
 Table of Contents                            *hardtime.nvim-table-of-contents*

--- a/lua/hardtime/config.lua
+++ b/lua/hardtime/config.lua
@@ -94,6 +94,7 @@ M.config = {
       "qf",
       "oil",
       "undotree",
+      "Trouble",
    },
    hints = {
       ["[kj][%^_]"] = {


### PR DESCRIPTION
The [trouble](https://github.com/folke/trouble.nvim) buffer is similar to a quickfix list. Hence, IMO hardtime should be disabled in this buffer.
