### PR TITLE
feat: add lspinfo and query to disabled filetypes

### DIFF
--- a/lua/hardtime/config.lua
+++ b/lua/hardtime/config.lua
@@ -76,6 +76,7 @@ M.config = {
       "help",
       "httpResult",
       "lazy",
+      "lspinfo",
       "Neogit*",
       "mason",
       "neotest-summary",

--- a/lua/hardtime/config.lua
+++ b/lua/hardtime/config.lua
@@ -87,6 +87,7 @@ M.config = {
       "notify",
       "prompt",
       "qf",
+      "query",
       "oil",
       "undotree",
       "Trouble",


### PR DESCRIPTION
Query is the filetype used in the neovim `:InspectTree`. While using this feature it's useful to use the `h,j,k,l` motions repeatedly.