### PR TITLE
feat: add `trouble` to disabled_filetypes for trouble v3

### DIFF
--- a/lua/hardtime/config.lua
+++ b/lua/hardtime/config.lua
@@ -90,6 +90,7 @@ M.config = {
       "query",
       "oil",
       "undotree",
+      "trouble",
       "Trouble",
       "fugitive",
    },


### PR DESCRIPTION
https://github.com/folke/trouble.nvim/blob/806c50491078b66daf13c408042f2e74da46d0ff/lua/trouble/view/window.lua#L97

filetype of Trouble has been changed from `Trouble` to `trouble`.