### PR TITLE
feat: Add callback function to notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ disabled_keys = {
 | `disabled_keys`       | table of strings/table pair  | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | Keys in what modes are disabled.                                                                                                                                              |
 | `disabled_filetypes`  | table of strings             | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | `hardtime.nvim` is disabled under these filetypes.                                                                                                                            |
 | `hints`               | table                        | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | `key` is a string pattern you want to match, `value` is a table of hint message and pattern length. Learn more about [Lua string pattern](https://www.lua.org/pil/20.2.html). |
-| `callback`          | table                          | nil | `callback` function can be used to override the default notification behavior |
+| `callback`          | function(text)               | vim.notify() | `callback` function can be used to override the default notification behavior |
 
 ### `hints` example 
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ disabled_keys = {
 | `disabled_keys`       | table of strings/table pair  | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | Keys in what modes are disabled.                                                                                                                                              |
 | `disabled_filetypes`  | table of strings             | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | `hardtime.nvim` is disabled under these filetypes.                                                                                                                            |
 | `hints`               | table                        | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | `key` is a string pattern you want to match, `value` is a table of hint message and pattern length. Learn more about [Lua string pattern](https://www.lua.org/pil/20.2.html). |
+| `callback`          | table                          | nil | `callback` function can be used to override the default notification behavior |
 
 ### `hints` example 
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ disabled_keys = {
 | `disabled_keys`       | table of strings/table pair  | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | Keys in what modes are disabled.                                                                                                                                              |
 | `disabled_filetypes`  | table of strings             | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | `hardtime.nvim` is disabled under these filetypes.                                                                                                                            |
 | `hints`               | table                        | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | `key` is a string pattern you want to match, `value` is a table of hint message and pattern length. Learn more about [Lua string pattern](https://www.lua.org/pil/20.2.html). |
-| `callback`          | function(text)               | vim.notify() | `callback` function can be used to override the default notification behavior |
+| `callback`            | function(text)               | `vim.notify`                                                                             | `callback` function can be used to override the default notification behavior.                                                                                                |
 
 ### `hints` example 
 

--- a/lua/hardtime/config.lua
+++ b/lua/hardtime/config.lua
@@ -351,8 +351,10 @@ M.config = {
          length = 6,
       },
    },
-   ---@type function | nil
-   callback = nil,
+   ---@type function
+   callback = function(text)
+      vim.notify(text, vim.log.levels.WARN, { title = "hardtime" })
+   end,
 }
 
 function M.set_defaults(user_config)

--- a/lua/hardtime/config.lua
+++ b/lua/hardtime/config.lua
@@ -351,6 +351,8 @@ M.config = {
          length = 6,
       },
    },
+   ---@type function | nil
+   callback = nil,
 }
 
 function M.set_defaults(user_config)

--- a/lua/hardtime/util.lua
+++ b/lua/hardtime/util.lua
@@ -34,7 +34,7 @@ end
 
 function M.should_reset()
    return M.get_time() - last_notification_time
-       > require("hardtime.config").config.max_time
+      > require("hardtime.config").config.max_time
 end
 
 function M.reset_notification()

--- a/lua/hardtime/util.lua
+++ b/lua/hardtime/util.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local config = require("hardtime.config").config
+
 local logger = require("hardtime.log").new({
    plugin = "hardtime.nvim",
    level = "info",
@@ -22,9 +24,13 @@ local last_notification_text
 local last_notification_time = M.get_time()
 
 function M.notify(text)
-   if text ~= last_notification_text then
-      logger.info(text)
-      vim.notify(text, vim.log.levels.WARN, { title = "hardtime" })
+   if config.callback then
+      config.callback(text)
+   else
+      if text ~= last_notification_text then
+         logger.info(text)
+         vim.notify(text, vim.log.levels.WARN, { title = "hardtime" })
+      end
    end
    last_notification_text = text
    last_notification_time = M.get_time()

--- a/lua/hardtime/util.lua
+++ b/lua/hardtime/util.lua
@@ -24,13 +24,9 @@ local last_notification_text
 local last_notification_time = M.get_time()
 
 function M.notify(text)
-   if config.callback then
+   if text ~= last_notification_text then
+      logger.info(text)
       config.callback(text)
-   else
-      if text ~= last_notification_text then
-         logger.info(text)
-         vim.notify(text, vim.log.levels.WARN, { title = "hardtime" })
-      end
    end
    last_notification_text = text
    last_notification_time = M.get_time()
@@ -38,7 +34,7 @@ end
 
 function M.should_reset()
    return M.get_time() - last_notification_time
-      > require("hardtime.config").config.max_time
+       > require("hardtime.config").config.max_time
 end
 
 function M.reset_notification()


### PR DESCRIPTION
This commit introduces a new `callback` function to the notification system. This function can be used to trigger custom events on a notification. It receives a config object and the notification text as parameters. The `callback` function is optional and is added to the `config` object in `config.lua`. The `notify` function in `util.lua` has been updated to call the `callback` function if it is provided.

This would be one way to handle a request we had in https://github.com/tris203/precognition.nvim/issues/62

But open to your ideas about implementation.

Draft as this is just a talking point for now