### PR TITLE
feat: remove dependency on plenary.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Learn more in this [blog post](https://m4xshen.dev/posts/vim-command-workflow/)
 -- lazy.nvim
 {
    "m4xshen/hardtime.nvim",
-   dependencies = { "MunifTanjim/nui.nvim", "nvim-lua/plenary.nvim" },
+   dependencies = { "MunifTanjim/nui.nvim" },
    opts = {}
 },
 ```

--- a/lua/hardtime/log.lua
+++ b/lua/hardtime/log.lua
@@ -168,11 +168,8 @@ log.new = function(config, standalone)
 
       -- Output to log file
       if config.use_file then
-         local outfile_parent_path =
-            require("plenary.path"):new(outfile):parent()
-         if not outfile_parent_path:exists() then
-            outfile_parent_path:mkdir({ parents = true })
-         end
+         local outfile_parent_path = vim.fs.dirname(outfile)
+         vim.fn.mkdir(outfile_parent_path, "p")
          local fp = assert(io.open(outfile, "a"))
          local str = config.fmt_msg(false, level_config.name, msg)
          fp:write(str)


### PR DESCRIPTION
Instead use built-in functions for determining the log directory.