### PR TITLE
fix: prevent unbounded growth of last_keys to avoid memory leaks

### DIFF
--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -123,6 +123,17 @@ local function reset_timer()
    end
 end
 
+local function get_max_keys_size()
+   local max_len = 0
+   for pattern, hint in pairs(config.hints) do
+      local len = hint.length or #pattern
+      if len > max_len then
+         max_len = len
+      end
+   end
+   return max_len
+end
+
 local M = {}
 M.is_plugin_enabled = false
 
@@ -195,6 +206,8 @@ function M.setup(user_config)
       })
    end
 
+   local max_keys_size = get_max_keys_size()
+
    vim.on_key(function(_, k)
       local mode = vim.fn.mode()
       if k == "" or mode == "c" or mode == "R" then
@@ -217,6 +230,10 @@ function M.setup(user_config)
 
       last_keys = last_keys .. key
       last_key = key
+
+      if #last_keys > max_keys_size then
+         last_keys = last_keys:sub(-max_keys_size)
+      end
 
       if not config.hint or not M.is_plugin_enabled or should_disable() then
          return

--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -123,17 +123,6 @@ local function reset_timer()
    end
 end
 
-local function get_max_keys_size()
-   local max_len = 0
-   for pattern, hint in pairs(config.hints) do
-      local len = hint.length or #pattern
-      if len > max_len then
-         max_len = len
-      end
-   end
-   return max_len
-end
-
 local M = {}
 M.is_plugin_enabled = false
 
@@ -206,7 +195,7 @@ function M.setup(user_config)
       })
    end
 
-   local max_keys_size = get_max_keys_size()
+   local max_keys_size = util.get_max_keys_size()
 
    vim.on_key(function(_, k)
       local mode = vim.fn.mode()

--- a/lua/hardtime/util.lua
+++ b/lua/hardtime/util.lua
@@ -45,4 +45,12 @@ function M.reset_notification()
    last_notification_text = nil
 end
 
+function M.get_max_keys_size()
+   local max_len = 0
+   for pattern, hint in pairs(config.hints) do
+      max_len = math.max(max_len, hint.length or #pattern)
+   end
+   return max_len
+end
+
 return M


### PR DESCRIPTION
Hi, while digging through the source code to make the plugin work correctly with `which-key.nvim`, I noticed a small issue with the `last_keys` variable used in `vim.on_key` callback.

`last_keys` is constantly appended after every keystroke, and there is no mechanism to limit its size, which could lead to potential memory leaks. This PR fixes the problem by limiting its size to the longest hint defined in `config.hints`.

I appreciate any feedback, thanks.