### PR TITLE
feat: add hint for using O instead of ko

### DIFF
--- a/lua/hardtime/config.lua
+++ b/lua/hardtime/config.lua
@@ -142,6 +142,12 @@ M.config = {
          end,
          length = 3,
       },
+      ["%D[k+]o"] = {
+         message = function(keys)
+            return "Use O instead of " .. keys:sub(2)
+         end,
+         length = 3,
+      },
       ["[^fFtT]li"] = {
          message = function()
             return "Use a instead of li"


### PR DESCRIPTION
There is already a hint for using "o" instead of "jO". This adds a hint for using "O" instead of "ko".