### PR TITLE
Add Avante to default disabled list

### DIFF
--- a/lua/hardtime/config.lua
+++ b/lua/hardtime/config.lua
@@ -99,6 +99,7 @@ M.config = {
       "fugitive",
       "VoltWindow",
       "undotree",
+      "Avante",
    },
    hints = {
       ["[kj][%^_]"] = {


### PR DESCRIPTION
https://github.com/yetone/avante.nvim
Avante filetype is basically a response from AI, so I believe disabling hardtime there makes sense.