### PR TITLE
fix: use `vim.opt.mouse` as default value for `old_mouse_state` ...

### DIFF
--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -5,7 +5,7 @@ local last_key = ""
 local last_keys = ""
 local last_time = util.get_time()
 local mappings
-local old_mouse_state = ""
+local old_mouse_state = vim.opt.mouse
 local timer = nil
 
 local config = require("hardtime.config").config


### PR DESCRIPTION
instead `""`

If Neovim switches to an disabled buffer after starting, `vim.old.mouse` is replaced with `old_mouse_state` in `restore_mouse()`, which is still empty.

`restore_mouse()` is called before `disable_mouse()` and `old_mouse_state` is only set in `disable_mouse()`.