### PR TITLE
fix: properly initialize `old_mouse_state`

### DIFF
--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -5,7 +5,7 @@ local last_key = ""
 local last_keys = ""
 local last_time = util.get_time()
 local mappings
-local old_mouse_state = ""
+local old_mouse_state = vim.opt.mouse
 local timer = nil
 
 local config = require("hardtime.config").config
@@ -206,16 +206,18 @@ function M.setup(user_config)
          end,
       })
 
-      vim.api.nvim_create_autocmd({ "BufEnter", "TermEnter" }, {
-         group = hardtime_group,
-         callback = function()
-            if should_disable() then
-               restore_mouse()
-            elseif config.disable_mouse then
+      if config.disable_mouse then
+         vim.api.nvim_create_autocmd({ "BufEnter", "TermEnter" }, {
+            group = hardtime_group,
+            callback = function()
+               if should_disable() then
+                  restore_mouse()
+                  return
+               end
                disable_mouse()
-            end
-         end,
-      })
+            end,
+         })
+      end
    end
 
    local max_keys_size = util.get_max_keys_size()


### PR DESCRIPTION
## Problem:
Old mouse state would be empty if the user sets `disable_mouse=false`, due to `disable_mouse` function not being called, and the initial `old_mouse_state` being set to a empty string.

## Solution:

Initialize `old_mouse_state` and only create the restore mouse autocommand if the user has not set `disable_mouse=false`.

-----------------------------------

Both changes would solve this problem alone. But I believe this make the code more robust.