### PR TITLE
feat: change disabled_filetypes to a key-value table for easier config

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,15 +77,6 @@ Your log file is at `~/.local/state/nvim/hardtime.nvim.log`.
 
 You can pass your config table into the `setup()` function or `opts` if you use lazy.nvim.
 
-If the option is a boolean, number, or array, your value will overwrite the default configuration.
-
-Example:
-
-```lua
--- Add "oil" to the disabled_filetypes
-disabled_filetypes = { "qf", "netrw", "NvimTree", "lazy", "mason", "oil" },
-```
-
 If the option is a table with a `key = value` pair, your value will overwrite the default if the key exists, and the pair will be appended to the default configuration if the key doesn't exist. You can set `key = {}` to remove the default key-value pair.
 
 Example:
@@ -95,6 +86,20 @@ Example:
 disabled_keys = {
    ["<Up>"] = {},
    ["<Space>"] = { "n", "x" },
+},
+```
+
+You can disable certain filetypes by adding them as a string to the `disabled_filetypes` field. You can also enable filetypes by adding them as a `key = value` schema where `value == false`.
+
+Example:
+
+```lua
+-- Add "oil" to the disabled_filetypes
+-- Enable hardtime in "lazy" and "dapui" filetypes
+disabled_filetypes = { 
+   "oil",
+   lazy = false,
+   ["dapui*"] = false,
 },
 ```
 
@@ -114,7 +119,7 @@ disabled_keys = {
 | `restricted_keys`        | table of strings/table pair  | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | Keys in what modes triggering the count mechanism.                                                                                                                            |
 | `restriction_mode`       | string (`"block" or "hint"`) | `"block"`                                                                                | The behavior when `restricted_keys` trigger count mechanism.                                                                                                                  |
 | `disabled_keys`          | table of strings/table pair  | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | Keys in what modes are disabled.                                                                                                                                              |
-| `disabled_filetypes`     | table of strings             | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | `hardtime.nvim` is disabled under these filetypes.                                                                                                                            |
+| `disabled_filetypes`     | table of strings/boolean pair  | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | `hardtime.nvim` is disabled under these filetypes.                                                                                                                            |
 | `hints`                  | table                        | [See Config](https://github.com/m4xshen/hardtime.nvim/blob/main/lua/hardtime/config.lua) | `key` is a string pattern you want to match, `value` is a table of hint message and pattern length. Learn more about [Lua string pattern](https://www.lua.org/pil/20.2.html). |
 | `callback`               | function(text)               | `vim.notify`                                                                             | `callback` function can be used to override the default notification behavior.                                                                                                |
 | `force_exit_insert_mode` | boolean                      | `false`                                                                                  | Enable forcing exit Insert mode if user is inactive in Insert mode.                                                                                                           |

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ Your log file is at `~/.local/state/nvim/hardtime.nvim.log`.
 
 You can pass your config table into the `setup()` function or `opts` if you use lazy.nvim.
 
-If the option is a table with a `key = value` pair, your value will overwrite the default if the key exists, and the pair will be appended to the default configuration if the key doesn't exist. You can set `key = {}` to remove the default key-value pair.
+If the option is a table (`key = value` pair), your `value` will overwrite the default if the `key` exists, and the pair will be appended to the default configuration if the `key` doesn't exist.
 
-Example:
+Examples:
 
 ```lua
 -- Remove <Up> keys and append <Space> to the disabled_keys
@@ -89,15 +89,9 @@ disabled_keys = {
 },
 ```
 
-You can disable certain filetypes by adding them as a string to the `disabled_filetypes` field. You can also enable filetypes by adding them as a `key = value` schema where `value == false`.
-
-Example:
-
 ```lua
--- Add "oil" to the disabled_filetypes
 -- Enable hardtime in "lazy" and "dapui" filetypes
 disabled_filetypes = { 
-   "oil",
    lazy = false,
    ["dapui*"] = false,
 },

--- a/lua/hardtime/config.lua
+++ b/lua/hardtime/config.lua
@@ -66,37 +66,37 @@ M.config = {
       ["<Right>"] = { "", "i" },
    },
    disabled_filetypes = {
-      "aerial",
-      "alpha",
-      "Avante",
-      "checkhealth",
-      "dapui*",
-      "db*",
-      "Diffview*",
-      "Dressing*",
-      "fugitive",
-      "help",
-      "httpResult",
-      "lazy",
-      "lspinfo",
-      "mason",
-      "minifiles",
-      "Neogit*",
-      "neo%-tree*",
-      "neotest%-summary",
-      "netrw",
-      "noice",
-      "notify",
-      "NvimTree",
-      "oil",
-      "prompt",
-      "qf",
-      "query",
-      "TelescopePrompt",
-      "Trouble",
-      "trouble",
-      "VoltWindow",
-      "undotree",
+      ["aerial"] = true,
+      ["alpha"] = true,
+      ["Avante"] = true,
+      ["checkhealth"] = true,
+      ["dapui*"] = true,
+      ["db*"] = true,
+      ["Diffview*"] = true,
+      ["Dressing*"] = true,
+      ["fugitive"] = true,
+      ["help"] = true,
+      ["httpResult"] = true,
+      ["lazy"] = true,
+      ["lspinfo"] = true,
+      ["mason"] = true,
+      ["minifiles"] = true,
+      ["Neogit*"] = true,
+      ["neo%-tree*"] = true,
+      ["neotest%-summary"] = true,
+      ["netrw"] = true,
+      ["noice"] = true,
+      ["notify"] = true,
+      ["NvimTree"] = true,
+      ["oil"] = true,
+      ["prompt"] = true,
+      ["qf"] = true,
+      ["query"] = true,
+      ["TelescopePrompt"] = true,
+      ["Trouble"] = true,
+      ["trouble"] = true,
+      ["VoltWindow"] = true,
+      ["undotree"] = true,
    },
    ui = {
       enter = true,
@@ -381,9 +381,24 @@ M.config = {
    end,
 }
 
+local function apply_user_disabled_filetypes(setting)
+   local tb = {}
+   for filetype, disabled in pairs(setting) do
+      if type(disabled) == "boolean" then
+         tb[filetype] = disabled
+      elseif type(filetype) == "number" then
+         tb[disabled] = true
+      end
+   end
+   M.config.disabled_filetypes =
+      vim.tbl_extend("force", M.config.disabled_filetypes, tb)
+end
+
 function M.set_defaults(user_config)
    for option, value in pairs(user_config) do
-      if type(value) == "table" and #value == 0 then
+      if option == "disabled_filetypes" then
+         apply_user_disabled_filetypes(value)
+      elseif type(value) == "table" and #value == 0 then
          for k, v in pairs(value) do
             if next(v) == nil then
                M.config[option][k] = nil

--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -38,9 +38,12 @@ local function get_return_key(key)
 end
 
 local function match_filetype(ft)
-   for _, value in pairs(config.disabled_filetypes) do
-      local matcher = "^" .. value .. (value:sub(-1) == "*" and "" or "$")
-      if ft:match(matcher) then
+   for filetype, is_disabled in pairs(config.disabled_filetypes) do
+      if filetype == ft and is_disabled then
+         return true
+      end
+      local matcher = "^" .. filetype .. (filetype:sub(-1) == "*" and "" or "$")
+      if ft:match(matcher) and is_disabled then
          return true
       end
    end
@@ -49,8 +52,7 @@ local function match_filetype(ft)
 end
 
 local function should_disable_hardtime()
-   return vim.tbl_contains(config.disabled_filetypes, vim.bo.ft)
-      or match_filetype(vim.bo.ft)
+   return match_filetype(vim.bo.ft)
       or vim.api.nvim_get_option_value("buftype", { buf = 0 }) == "terminal"
       or vim.fn.reg_executing() ~= ""
       or vim.fn.reg_recording() ~= ""


### PR DESCRIPTION
Having to list out all the filetypes disabled by default to disable another filetype creates too much clutter in a users config.

Making `disabled_filetypes` a key-value (string-boolean) table allows for more flexible configuration along the same lines as the `disabled_keys` table.

Setting `disabled_filetypes = { "oil", lazy = false, ["dapui*"] = false }` will disable hardtime in oil, and enable it in lazy and dapui filetypes. It will also retain all existing `disabled_filetypes` values. This means existing user configs should continue acting as expected.