### PR TITLE
Add `snacks_dashboard` to `disabled_filetypes`

### DIFF
--- a/lua/hardtime/config.lua
+++ b/lua/hardtime/config.lua
@@ -92,6 +92,7 @@ M.config = {
       ["prompt"] = true,
       ["qf"] = true,
       ["query"] = true,
+      ["snacks_dashboard"] = true,
       ["TelescopePrompt"] = true,
       ["Trouble"] = true,
       ["trouble"] = true,


### PR DESCRIPTION
It has a list in the dashboard and I wanted to move with just hjkl keys.