### PR TITLE
Prevent/deter 1h, 1j, 1k, and 1l motions

### DIFF
--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -81,7 +81,7 @@ local function handler(key)
 
    -- reset
    if config.resetting_keys[key] then
-      if !forbidden_technique and key == 1 then
+      if not forbidden_technique and key == 1 then
          forbidden_technique = true
       else
          forbidden_technique = false

--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -81,7 +81,8 @@ local function handler(key)
 
    -- reset
    if config.resetting_keys[key] then
-      if not forbidden_technique and key == 1 then
+
+      if not forbidden_technique and key == "1" then
          forbidden_technique = true
       else
          forbidden_technique = false
@@ -102,8 +103,13 @@ local function handler(key)
       or is_different_key
    then
       if is_different_key and forbidden_technique then
+
          if key == "h" or key == "j" or key == "k" or key == "l" then
             util.notify("1" .. key .. " is frowned upon! Try just " .. key)
+			vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", false)
+			forbidden_technique = false
+
+			return ""
          end
          forbidden_technique = false
       end

--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -105,7 +105,8 @@ local function handler(key)
          if key == "h" or key == "j" or key == "k" or key == "l" then
             util.notify("1" .. key .. " is frowned upon! Try just " .. key)
          end
-      forbidden_technique = false
+         forbidden_technique = false
+      end
       if should_reset_key_count or is_different_key then
          key_count = 1
          util.reset_notification()

--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -103,7 +103,7 @@ local function handler(key)
    then
       if is_different_key and forbidden_technique then
          if key == "h" or key == "j" or key == "k" or key == "l" then
-            util.notify("1" .. key .. " is frowned upon! Try just " .. key ..)
+            util.notify("1" .. key .. " is frowned upon! Try just " .. key)
          end
       forbidden_technique = false
       if should_reset_key_count or is_different_key then


### PR DESCRIPTION
While using the plugin, I wondered how it stopped input, which led me to find that any number + motion was considered fine. There are considerations for other motions such as w, b, e etc. Preventing or deterring prepending 1 to the command, but hjkl came to mind as primary targets. I don't think this exact implementation should be the true implementation, but I think it's enough to show the concept