### PR TITLE
feat: Add `hardtime_report` as a specific filetype to report

### DIFF
--- a/lua/hardtime/report.lua
+++ b/lua/hardtime/report.lua
@@ -36,6 +36,12 @@ function M.report()
       popup:unmount()
    end)
 
+   vim.api.nvim_set_option_value(
+      "filetype",
+      "hardtime_report",
+      { buf = popup.bufnr }
+   )
+
    for i, pair in ipairs(sorted_hints) do
       local content = string.format("%d. %s (%d times)", i, pair[1], pair[2])
 


### PR DESCRIPTION
This adds a Hardtime specific filetype to the report popup. It would allow users to add their own functionality around the report e.g. adding a keymap to close it with `q`.