### PR TITLE
Fix hardtime changing mappings between modes

### DIFF
--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -171,7 +171,19 @@ end
 local clear_autocmds = function()
    vim.api.nvim_clear_autocmds({ group = hardtime_group })
 end
-
+local function setup_handler(key, mode)
+   -- lazy insert proper mappings into mappings for get_return_key
+   if mappings[mode] == nil then
+      mappings[mode] = vim.api.nvim_get_keymap(mode);
+   end
+   vim.keymap.set(mode, key, function()
+      return handler(key, mode)
+   end, {
+      noremap = true,
+      expr = true,
+      desc = "which_key_ignore",
+   })
+end
 function M.enable()
    if M.is_plugin_enabled then
       return
@@ -180,14 +192,6 @@ function M.enable()
    M.is_plugin_enabled = true
    mappings = {
       n = vim.api.nvim_get_keymap("n"),
-      v = vim.api.nvim_get_keymap("v"),
-      s = vim.api.nvim_get_keymap("s"),
-      x = vim.api.nvim_get_keymap("x"),
-      o = vim.api.nvim_get_keymap("o"),
-      i = vim.api.nvim_get_keymap("i"),
-      l = vim.api.nvim_get_keymap("l"),
-      c = vim.api.nvim_get_keymap("c"),
-      t = vim.api.nvim_get_keymap("t"),
    }
 
    setup_autocmds()
@@ -201,17 +205,16 @@ function M.enable()
       config.config.restricted_keys,
       config.config.disabled_keys,
    }
-
    for _, keys in ipairs(keys_groups) do
       for key, mode in pairs(keys) do
          if mode then
-            vim.keymap.set(mode, key, function()
-               return handler(key, vim.api.nvim_get_mode().mode:lower())
-            end, {
-               noremap = true,
-               expr = true,
-               desc = "which_key_ignore",
-            })
+            if type(mode) == "table" then
+               for s_mode in vim.tbl_keys(mode) do
+                  setup_handler(key, s_mode)
+               end
+            else
+               setup_handler(key, mode)
+            end
          end
       end
    end

--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -237,7 +237,19 @@ function M.disable()
 
    for _, keys in ipairs(keys_groups) do
       for key, mode in pairs(keys) do
-         pcall(vim.keymap.del, mode, key)
+         if mode then
+            if type(mode) == "table" then
+               for _, s_mode in ipairs(mode) do
+                  vim.keymap.set(mode, key, function()
+                     get_return_key(key, s_mode)
+                  end)
+               end
+            else
+               vim.keymap.set(mode, key, function()
+                  get_return_key(key, mode)
+               end)
+            end
+         end
       end
    end
 end

--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -19,7 +19,6 @@ end
 local function restore_mouse()
    vim.o.mouse = old_mouse_state
 end
-
 local function get_return_key(key, mode)
    for _, mapping in ipairs(mappings[mode]) do
       if mapping.lhs == key then
@@ -57,9 +56,11 @@ local function should_disable_hardtime()
       or vim.fn.reg_executing() ~= ""
       or vim.fn.reg_recording() ~= ""
 end
+local M = {}
+M.is_plugin_enabled = false
 
 local function handler(key, mode)
-   if should_disable_hardtime() then
+   if should_disable_hardtime() or not M.is_plugin_enabled then
       return get_return_key(key, mode)
    end
 
@@ -143,9 +144,6 @@ local function reset_timer()
    end
 end
 
-local M = {}
-M.is_plugin_enabled = false
-
 local function setup_autocmds()
    vim.api.nvim_create_autocmd("InsertEnter", {
       group = hardtime_group,
@@ -190,33 +188,11 @@ function M.enable()
    end
 
    M.is_plugin_enabled = true
-   mappings = {
-      n = vim.api.nvim_get_keymap("n"),
-   }
 
    setup_autocmds()
 
    if config.config.disable_mouse then
       disable_mouse()
-   end
-
-   local keys_groups = {
-      config.config.resetting_keys,
-      config.config.restricted_keys,
-      config.config.disabled_keys,
-   }
-   for _, keys in ipairs(keys_groups) do
-      for key, mode in pairs(keys) do
-         if mode then
-            if type(mode) == "table" then
-               for _, s_mode in ipairs(mode) do
-                  setup_handler(key, s_mode)
-               end
-            else
-               setup_handler(key, mode)
-            end
-         end
-      end
    end
 end
 
@@ -228,30 +204,6 @@ function M.disable()
    M.is_plugin_enabled = false
    restore_mouse()
    clear_autocmds()
-
-   local keys_groups = {
-      config.config.resetting_keys,
-      config.config.restricted_keys,
-      config.config.disabled_keys,
-   }
-
-   for _, keys in ipairs(keys_groups) do
-      for key, mode in pairs(keys) do
-         if mode then
-            if type(mode) == "table" then
-               for _, s_mode in ipairs(mode) do
-                  vim.keymap.set(mode, key, function()
-                     get_return_key(key, s_mode)
-                  end)
-               end
-            else
-               vim.keymap.set(mode, key, function()
-                  get_return_key(key, mode)
-               end)
-            end
-         end
-      end
-   end
 end
 
 function M.toggle()
@@ -266,6 +218,29 @@ local function setup(user_config)
    user_config = user_config or {}
    config.migrate_old_config(user_config)
    config.config = vim.tbl_deep_extend("force", config.config, user_config)
+   mappings = {
+      n = vim.api.nvim_get_keymap("n"),
+   }
+
+   local keys_groups = {
+      config.config.resetting_keys,
+      config.config.restricted_keys,
+      config.config.disabled_keys,
+   }
+
+   for _, keys in ipairs(keys_groups) do
+      for key, mode in pairs(keys) do
+         if mode then
+            if type(mode) == "table" then
+               for _, s_mode in ipairs(mode) do
+                  setup_handler(key, s_mode)
+               end
+            else
+               setup_handler(key, mode)
+            end
+         end
+      end
+   end
 
    if config.config.enabled then
       M.enable()

--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -20,8 +20,8 @@ local function restore_mouse()
    vim.o.mouse = old_mouse_state
 end
 
-local function get_return_key(key)
-   for _, mapping in ipairs(mappings) do
+local function get_return_key(key, mode)
+   for _, mapping in ipairs(mappings[mode]) do
       if mapping.lhs == key then
          if mapping.callback then
             local success, result = pcall(mapping.callback)
@@ -53,14 +53,14 @@ end
 
 local function should_disable_hardtime()
    return match_filetype(vim.bo.ft)
-      or vim.api.nvim_get_option_value("buftype", { buf = 0 }) == "terminal"
-      or vim.fn.reg_executing() ~= ""
-      or vim.fn.reg_recording() ~= ""
+       or vim.api.nvim_get_option_value("buftype", { buf = 0 }) == "terminal"
+       or vim.fn.reg_executing() ~= ""
+       or vim.fn.reg_recording() ~= ""
 end
 
-local function handler(key)
+local function handler(key, mode)
    if should_disable_hardtime() then
-      return get_return_key(key)
+      return get_return_key(key, mode)
    end
 
    local curr_time = util.get_time()
@@ -86,17 +86,17 @@ local function handler(key)
    end
 
    if config.config.restricted_keys[key] == nil then
-      return get_return_key(key)
+      return get_return_key(key, mode)
    end
 
    -- restrict
    local should_reset_key_count = curr_time - last_time > config.config.max_time
    local is_different_key = config.config.allow_different_key
-      and key ~= last_key
+       and key ~= last_key
    if
-      key_count < config.config.max_count
-      or should_reset_key_count
-      or is_different_key
+       key_count < config.config.max_count
+       or should_reset_key_count
+       or is_different_key
    then
       if should_reset_key_count or is_different_key then
          key_count = 1
@@ -126,7 +126,7 @@ local function handler(key)
    end
 
    if config.config.restriction_mode == "hint" then
-      return get_return_key(key)
+      return get_return_key(key, mode)
    end
    return ""
 end
@@ -137,7 +137,7 @@ local function reset_timer()
    end
 
    if
-      not should_disable_hardtime() and config.config.force_exit_insert_mode
+       not should_disable_hardtime() and config.config.force_exit_insert_mode
    then
       timer = vim.defer_fn(util.stopinsert, config.config.max_insert_idle_ms)
    end
@@ -178,7 +178,18 @@ function M.enable()
    end
 
    M.is_plugin_enabled = true
-   mappings = vim.api.nvim_get_keymap("n")
+   mappings = {
+      n = vim.api.nvim_get_keymap("n"),
+      v = vim.api.nvim_get_keymap("v"),
+      s = vim.api.nvim_get_keymap("s"),
+      x = vim.api.nvim_get_keymap("x"),
+      o = vim.api.nvim_get_keymap("o"),
+      i = vim.api.nvim_get_keymap("i"),
+      l = vim.api.nvim_get_keymap("l"),
+      c = vim.api.nvim_get_keymap("c"),
+      t = vim.api.nvim_get_keymap("t"),
+
+   }
 
    setup_autocmds()
 
@@ -282,9 +293,9 @@ local function setup(user_config)
       end
 
       if
-         not config.config.hint
-         or not M.is_plugin_enabled
-         or should_disable_hardtime()
+          not config.config.hint
+          or not M.is_plugin_enabled
+          or should_disable_hardtime()
       then
          return
       end

--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -106,7 +106,7 @@ local function handler(key, mode)
       end
 
       last_time = util.get_time()
-      return get_return_key(key)
+      return get_return_key(key, mode)
    end
 
    if config.config.notification then
@@ -188,7 +188,6 @@ function M.enable()
       l = vim.api.nvim_get_keymap("l"),
       c = vim.api.nvim_get_keymap("c"),
       t = vim.api.nvim_get_keymap("t"),
-
    }
 
    setup_autocmds()
@@ -207,7 +206,7 @@ function M.enable()
       for key, mode in pairs(keys) do
          if mode then
             vim.keymap.set(mode, key, function()
-               return handler(key)
+               return handler(key, vim.api.nvim_get_mode().mode:lower())
             end, {
                noremap = true,
                expr = true,

--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -53,9 +53,9 @@ end
 
 local function should_disable_hardtime()
    return match_filetype(vim.bo.ft)
-       or vim.api.nvim_get_option_value("buftype", { buf = 0 }) == "terminal"
-       or vim.fn.reg_executing() ~= ""
-       or vim.fn.reg_recording() ~= ""
+      or vim.api.nvim_get_option_value("buftype", { buf = 0 }) == "terminal"
+      or vim.fn.reg_executing() ~= ""
+      or vim.fn.reg_recording() ~= ""
 end
 
 local function handler(key, mode)
@@ -92,11 +92,11 @@ local function handler(key, mode)
    -- restrict
    local should_reset_key_count = curr_time - last_time > config.config.max_time
    local is_different_key = config.config.allow_different_key
-       and key ~= last_key
+      and key ~= last_key
    if
-       key_count < config.config.max_count
-       or should_reset_key_count
-       or is_different_key
+      key_count < config.config.max_count
+      or should_reset_key_count
+      or is_different_key
    then
       if should_reset_key_count or is_different_key then
          key_count = 1
@@ -137,7 +137,7 @@ local function reset_timer()
    end
 
    if
-       not should_disable_hardtime() and config.config.force_exit_insert_mode
+      not should_disable_hardtime() and config.config.force_exit_insert_mode
    then
       timer = vim.defer_fn(util.stopinsert, config.config.max_insert_idle_ms)
    end
@@ -174,7 +174,7 @@ end
 local function setup_handler(key, mode)
    -- lazy insert proper mappings into mappings for get_return_key
    if mappings[mode] == nil then
-      mappings[mode] = vim.api.nvim_get_keymap(mode);
+      mappings[mode] = vim.api.nvim_get_keymap(mode)
    end
    vim.keymap.set(mode, key, function()
       return handler(key, mode)
@@ -295,9 +295,9 @@ local function setup(user_config)
       end
 
       if
-          not config.config.hint
-          or not M.is_plugin_enabled
-          or should_disable_hardtime()
+         not config.config.hint
+         or not M.is_plugin_enabled
+         or should_disable_hardtime()
       then
          return
       end

--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -209,7 +209,7 @@ function M.enable()
       for key, mode in pairs(keys) do
          if mode then
             if type(mode) == "table" then
-               for s_mode in vim.tbl_keys(mode) do
+               for _, s_mode in ipairs(mode) do
                   setup_handler(key, s_mode)
                end
             else

--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -20,20 +20,19 @@ local function restore_mouse()
    vim.o.mouse = old_mouse_state
 end
 local function get_return_key(key, mode)
-   for _, mapping in ipairs(mappings[mode]) do
-      if mapping.lhs == key then
-         if mapping.callback then
-            local success, result = pcall(mapping.callback)
-            if success then
-               return result
-            end
-
-            return vim.schedule(mapping.callback)
-         end
-         return util.try_eval(mapping.rhs)
-      end
+   local mapping = mappings[mode][key]
+   if not mapping then
+      return key
    end
-   return key
+   if mapping.callback then
+      local success, result = pcall(mapping.callback)
+      if success then
+         return result
+      end
+
+      return vim.schedule(mapping.callback)
+   end
+   return util.try_eval(mapping.rhs)
 end
 
 local function match_filetype(ft)
@@ -56,11 +55,9 @@ local function should_disable_hardtime()
       or vim.fn.reg_executing() ~= ""
       or vim.fn.reg_recording() ~= ""
 end
-local M = {}
-M.is_plugin_enabled = false
 
 local function handler(key, mode)
-   if should_disable_hardtime() or not M.is_plugin_enabled then
+   if should_disable_hardtime() then
       return get_return_key(key, mode)
    end
 
@@ -144,6 +141,9 @@ local function reset_timer()
    end
 end
 
+local M = {}
+M.is_plugin_enabled = false
+
 local function setup_autocmds()
    vim.api.nvim_create_autocmd("InsertEnter", {
       group = hardtime_group,
@@ -169,30 +169,51 @@ end
 local clear_autocmds = function()
    vim.api.nvim_clear_autocmds({ group = hardtime_group })
 end
-local function setup_handler(key, mode)
-   -- lazy insert proper mappings into mappings for get_return_key
-   if mappings[mode] == nil then
-      mappings[mode] = vim.api.nvim_get_keymap(mode)
-   end
-   vim.keymap.set(mode, key, function()
-      return handler(key, mode)
-   end, {
-      noremap = true,
-      expr = true,
-      desc = "which_key_ignore",
-   })
-end
+
 function M.enable()
    if M.is_plugin_enabled then
       return
    end
 
    M.is_plugin_enabled = true
+   mappings = {}
 
    setup_autocmds()
 
    if config.config.disable_mouse then
       disable_mouse()
+   end
+
+   local keys_groups = {
+      config.config.resetting_keys,
+      config.config.restricted_keys,
+      config.config.disabled_keys,
+   }
+
+   for _, keys in ipairs(keys_groups) do
+      for key, mode in pairs(keys) do
+         if mode then
+            --- @type string[]
+            local mode_table = type(mode) == "table" and mode or { mode }
+            for _, s_mode in ipairs(mode_table) do
+               -- lazy insert proper mappings into mappings for get_return_key
+               if mappings[s_mode] == nil then
+                  local mappings_tbl = vim.api.nvim_get_keymap(s_mode)
+                  mappings[s_mode] = {}
+                  for _, mapping in ipairs(mappings_tbl) do
+                     mappings[s_mode][mapping.lhs] = mapping
+                  end
+               end
+               vim.keymap.set(s_mode, key, function()
+                  return handler(key, s_mode)
+               end, {
+                  noremap = true,
+                  expr = true,
+                  desc = "which_key_ignore",
+               })
+            end
+         end
+      end
    end
 end
 
@@ -204,6 +225,61 @@ function M.disable()
    M.is_plugin_enabled = false
    restore_mouse()
    clear_autocmds()
+
+   local keys_groups = {
+      config.config.resetting_keys,
+      config.config.restricted_keys,
+      config.config.disabled_keys,
+   }
+
+   -- delete or restore keymaps
+   for _, keys in ipairs(keys_groups) do
+      for key, mode in pairs(keys) do
+         if mode then
+            --- @type string[]
+            local mode_table = type(mode) == "table" and mode or { mode }
+            for _, s_mode in ipairs(mode_table) do
+               local mapping = mappings[s_mode][key]
+               if not mapping then
+                  vim.keymap.del(s_mode, key)
+               else
+                  local keymap_opts = {}
+                  for _, opt_key in ipairs({
+                     "callback",
+                     "expr",
+                     "desc",
+                     "noremap",
+                     "replace_keycodes",
+                     "silent",
+                     "script",
+                     "nowait",
+                     "unique",
+                  }) do
+                     if mapping[opt_key] then
+                        keymap_opts[opt_key] = mapping[opt_key]
+                     end
+                  end
+                  if mapping.bufnr then
+                     vim.api.nvim_buf_set_keymap(
+                        mapping.bufnr,
+                        s_mode,
+                        key,
+                        mapping.rhs,
+                        keymap_opts
+                     )
+                  else
+                     vim.api.nvim_set_keymap(
+                        s_mode,
+                        key,
+                        mapping.rhs,
+                        keymap_opts
+                     )
+                  end
+               end
+            end
+         end
+      end
+   end
 end
 
 function M.toggle()
@@ -218,29 +294,6 @@ local function setup(user_config)
    user_config = user_config or {}
    config.migrate_old_config(user_config)
    config.config = vim.tbl_deep_extend("force", config.config, user_config)
-   mappings = {
-      n = vim.api.nvim_get_keymap("n"),
-   }
-
-   local keys_groups = {
-      config.config.resetting_keys,
-      config.config.restricted_keys,
-      config.config.disabled_keys,
-   }
-
-   for _, keys in ipairs(keys_groups) do
-      for key, mode in pairs(keys) do
-         if mode then
-            if type(mode) == "table" then
-               for _, s_mode in ipairs(mode) do
-                  setup_handler(key, s_mode)
-               end
-            else
-               setup_handler(key, mode)
-            end
-         end
-      end
-   end
 
    if config.config.enabled then
       M.enable()


### PR DESCRIPTION
I discovered it because I have those mappings:
```lua
vim.keymap.set('n', 'J', 'mzJ`z')
vim.keymap.set('v', 'J', [[:<C-u> execute "'<,'>m '>+".v:count1<CR>gv=gv]])
vim.keymap.set('v', 'K', [[:<C-u> execute "'<,'>m '<--".v:count1<CR>gv=gv]])
```
I recently changed the last two from 
```lua
vim.keymap.set('v', 'J', ":m '>+1<CR>gv=gv")
vim.keymap.set('v', 'K', ":m '<-2<CR>gv=gv")
```
and wanted to add them to hardtime - to my surprise, the functionality broke down.

After investigating I found that `mappings` which hardtime uses gets only mappings from normal mode, in turn replacing `v` mapping with `n` mapping for `J` after I enabled them in my hardtime config


