### PR TITLE
fix: prevent premature loading of which-key.nvim

### DIFF
--- a/lua/hardtime/init.lua
+++ b/lua/hardtime/init.lua
@@ -260,9 +260,12 @@ local function setup(user_config)
       end
 
       -- ignore key if it is triggering which-key.nvim
-      local has_wk, wk = pcall(require, "which-key.state")
-      if has_wk and wk.state ~= nil then
-         return
+      local has_wk = package.loaded["which-key.state"] ~= nil
+      if has_wk then
+         local wk = require("which-key.state")
+         if wk.state ~= nil then
+            return
+         end
       end
 
       local key = vim.fn.keytrans(k)


### PR DESCRIPTION
### Problem
The recent fix #155 introduced `pcall(require, "which-key.state")`. However, when using package managers like `lazy.nvim`, calling `require` on a lazy-loaded plugin's module will immediately force-load the plugin on the very first keystroke, bypassing any user-defined lazy-loading configurations (e.g. `cmd`, `keys`, or `event` for `which-key`).

### Solution
Instead of directly calling `require`, check `package.loaded["which-key.state"] ~= nil` first. 

This prevents `lazy.nvim`'s global `require` hook from intercepting the call and loading the plugin prematurely. If `which-key` is already loaded, we then safely perform the `require` as before.
